### PR TITLE
Issue#3 context not in error map

### DIFF
--- a/src/hvl/plugin/parmorel/handlers/RepairHandler.java
+++ b/src/hvl/plugin/parmorel/handlers/RepairHandler.java
@@ -102,10 +102,10 @@ public class RepairHandler implements IHandler {
 	 * 
 	 * @return the created duplicate
 	 */
-	private File createDuplicateFileFrom(File selectedFile) {
-		File destinationFile = new File(selectedFile.getParent() + "_temp_" + selectedFile.getName());
+	private File createDuplicateFileFrom(File original) {
+		File destinationFile = new File(original.getParent() + "_temp_" + original.getName());
 		try {
-			Files.copy(selectedFile.toPath(), destinationFile.toPath());
+			Files.copy(original.toPath(), destinationFile.toPath());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/hvl/plugin/parmorel/handlers/RepairHandler.java
+++ b/src/hvl/plugin/parmorel/handlers/RepairHandler.java
@@ -38,8 +38,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ListSelectionDialog;
 
-import hvl.projectparmorel.ml.Error;
-import hvl.projectparmorel.ml.ErrorExtractor;
 import hvl.projectparmorel.ml.ModelFixer;
 import hvl.projectparmorel.ml.QModelFixer;
 
@@ -104,23 +102,15 @@ public class RepairHandler implements IHandler {
 	 * @param preferences
 	 */
 	private void fixSelectedModelWith(List<Integer> preferences) {
-		modelFixer.setPreferences(preferences); //ok
+		modelFixer.setPreferences(preferences);
 
 		File file = getSelectedFile();
 		file = new File("/Users/Magnus/Skole/DAT300/EclipseWorkspace/ParmorelRunnable/mutants/b10.ecore");
-		File destinationFile = createDuplicateFileFrom(file); //ok
-		URI uri = URI.createFileURI(destinationFile.getAbsolutePath()); //ok
-		Resource model = modelFixer.getModel(uri); //ok
+		File destinationFile = createDuplicateFileFrom(file);
+		URI uri = URI.createFileURI(destinationFile.getAbsolutePath());
+		Resource model = modelFixer.getModel(uri);
 		
-		Resource modelCopy = modelFixer.copy(model, uri); //ok
-		List<Error> errors = ErrorExtractor.extractErrorsFrom(modelCopy); //ok
-		System.out.println("Errors: " + errors.toString());
-		
-//		Resource auxModel = modelFixer.copy(model, uri);
-//		List<hvl.projectparmorel.ml.Error> errors = ErrorExtractor.extractErrorsFrom(auxModel);
-//		System.out.println("INITIAL ERRORS:" + errors.toString());
-		
-		modelFixer.fixModel(model, uri); //ok
+		modelFixer.fixModel(model, uri);
 
 		compare(file, destinationFile);
 	}
@@ -145,10 +135,9 @@ public class RepairHandler implements IHandler {
 	 * @return the created duplicate
 	 */
 	private File createDuplicateFileFrom(File original) {
-		File destinationFile = new File(original.getParent() + "_temp_" + original.getName()); //ok
+		File destinationFile = new File(original.getParent() + "_temp_" + original.getName());
 		try {
-//			java.nio.file.Path p = java.nio.file.FileSystems.getDefault().getPath("/Users/Magnus/Skole/DAT300/EclipseWorkspace/ParmorelRunnable/mutants/b10.ecore");
-			Files.copy(original.toPath(), destinationFile.toPath()); //ok
+			Files.copy(original.toPath(), destinationFile.toPath());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/hvl/plugin/parmorel/handlers/RepairHandler.java
+++ b/src/hvl/plugin/parmorel/handlers/RepairHandler.java
@@ -15,19 +15,13 @@ import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.commands.IHandlerListener;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.notify.AdapterFactory;
-import org.eclipse.emf.common.util.BasicMonitor;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.compare.Comparison;
-import org.eclipse.emf.compare.Diff;
 import org.eclipse.emf.compare.EMFCompare;
 import org.eclipse.emf.compare.domain.ICompareEditingDomain;
 import org.eclipse.emf.compare.domain.impl.EMFCompareEditingDomain;
 import org.eclipse.emf.compare.ide.ui.internal.configuration.EMFCompareConfiguration;
 import org.eclipse.emf.compare.ide.ui.internal.editor.ComparisonEditorInput;
-import org.eclipse.emf.compare.ide.ui.internal.editor.ComparisonScopeEditorInput;
-import org.eclipse.emf.compare.merge.BatchMerger;
-import org.eclipse.emf.compare.merge.IBatchMerger;
-import org.eclipse.emf.compare.merge.IMerger;
 import org.eclipse.emf.compare.scope.DefaultComparisonScope;
 import org.eclipse.emf.compare.scope.IComparisonScope;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -47,6 +41,7 @@ import org.eclipse.ui.dialogs.ListSelectionDialog;
 import hvl.projectparmorel.ml.ModelFixer;
 import hvl.projectparmorel.ml.QModelFixer;
 
+@SuppressWarnings("restriction")
 public class RepairHandler implements IHandler {
 
 	private String shorterSequences = "Prefer shorter sequences of actions";
@@ -207,7 +202,6 @@ public class RepairHandler implements IHandler {
 		AdapterFactory adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
 
 		CompareConfiguration configuration = new CompareConfiguration();
-		@SuppressWarnings("restriction")
 		CompareEditorInput input = new ComparisonEditorInput(new EMFCompareConfiguration(configuration), comparison,
 				editingDomain, adapterFactory);
 


### PR DESCRIPTION
Added a list of unsupported errors, and this fixes the issue. I still don't understand why more errors are found when launched from the plugin, maybe it is something Eclipse does when processing the models...

closes #3  